### PR TITLE
Fix issues with plugins loaded from disk

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-#! /usr/bin/env node
+#!/usr/bin/env node
 
 /**********
  * Modules

--- a/index.js
+++ b/index.js
@@ -66,6 +66,11 @@ function getCurrentVersions(){
 
     installedPlugins.forEach(function(plugin){
         plugins[plugin.id]['installed'] = plugin.version;
+        if (plugins[plugin.id]) {
+            plugins[plugin.id]['installed'] = plugin.version;
+        } else {
+            logger.log('Plugin ' + plugin.id + ' not found');
+        }
     });
     checkRemoteVersions();
 }

--- a/index.js
+++ b/index.js
@@ -69,8 +69,7 @@ function getCurrentVersions(){
     logger.debug("Reading installed plugin versions");
     var installedPlugins = pluginInfoProvider.getAllWithinSearchPath(PLUGINS_DIR);
 
-    installedPlugins.forEach(function(plugin){
-        plugins[plugin.id]['installed'] = plugin.version;
+    installedPlugins.forEach(function(plugin){ 
         if (plugins[plugin.id]) {
             plugins[plugin.id]['installed'] = plugin.version;
         } else {


### PR DESCRIPTION
I have a few plugins I wrote that are loaded from disk, this was crashing getCurrentVersions.  Small patch to ignore plugins it knows nothing about.  BTW love this little util, I had written some scripts to do some of this, but this is so much better.