### PR TITLE
Fix for case when npm view pkg version returns multiple empty lines

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,8 +111,13 @@ function checkRegistrySource(id, source){
         var version;
         if(stdout.match('@')){
             var versions = stdout.split('\n');
-            versions.pop();
-            version = versions.pop().match(/@([\d.]+)/)[1];
+            while (versions.length) {
+                version = versions.pop();
+                if (version) {
+                    version = version.match(/@([\d.]+)/)[1];
+                    break;
+                }
+            }
         }else{
             version = stdout;
         }


### PR DESCRIPTION
Fixes the following crash:

    TypeError: Cannot read property '1' of null
        at ...\npm\node_modules\cordova-check-plugins\index.js:115:56
        at ChildProcess.exithandler (child_process.js:742:7)
        at ChildProcess.emit (events.js:110:17)
        at maybeClose (child_process.js:1015:16)
        at Process.ChildProcess._handle.onexit (child_process.js:1087:5)

I found that it was caused by npm view pkg version returning 2 empty lines in its output instead of the 1 that is assumed in the code. Fixed the code to handle multiple empty lines.

I am using npm 2.9.1 and nodejs 0.12.3 on Windows 10.