### PR TITLE
Allow usage of private git repository URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,8 +31,8 @@ try{
  ***********/
 var PLUGINS_DIR = './plugins/',
     FETCH_FILE = PLUGINS_DIR + 'fetch.json',
-    GITHUB_HTTPS_REGEX = /https:\/\/github\.com\/([^\/]+)\/([^\/]+)$/,
-    GITHUB_GIT_REGEX = /git:\/\/github\.com\/([^\/]+)\/([^\/.]+)(?:\.git)?/;
+    GITHUB_HTTPS_REGEX = /^https:\/\/(?:\w*:?\w*@?)github\.com\/([^\/]+)\/([^\/.]+)(?:\.git)?$/,
+    GITHUB_GIT_REGEX = /^git:\/\/(?:\w*:?\w*@?)github\.com\/([^\/]+)\/([^\/.]+)(?:\.git)?$/;
 
 /******************
  * Global variables


### PR DESCRIPTION
Updated both regexes to allow private git repository URL, by including user information (username and password), according to RFC 1738 (http://www.rfc-base.org/txt/rfc-1738.txt)

GITHUB_HTTPS_REGEX : http://rubular.com/r/kdl5Mj8C95
GITHUB_GIT_REGEX : http://rubular.com/r/VxSZhqWb4m